### PR TITLE
Add color space and alpha mode conversion support

### DIFF
--- a/crates/ctt-cli/src/args.rs
+++ b/crates/ctt-cli/src/args.rs
@@ -14,14 +14,16 @@ pub struct Args {
     #[arg(short, long, required_unless_present = "list_encoders")]
     pub output: Option<PathBuf>,
 
-    /// Compression format. Bare (bc1, bc7) or prefixed with encoder (intel_bc7, bc7e_bc7).
+    /// Target format. Bare (bc1, bc7) or prefixed with encoder (intel_bc7, bc7e_bc7).
     /// ASTC formats use astc_WxH (e.g. astc_4x4, astc_8x8, astc_12x12).
-    #[arg(short, long, required_unless_present = "list_encoders")]
+    /// Uncompressed formats use WebGPU (rgba8unorm) or Vulkan (r8g8b8a8_unorm) names.
+    /// If omitted, the input format is preserved without compression.
+    #[arg(short, long)]
     pub format: Option<String>,
 
-    /// Output container format.
-    #[arg(short, long, default_value = "ktx2")]
-    pub container: ContainerArg,
+    /// Output container format. Inferred from the output file extension when omitted.
+    #[arg(short, long)]
+    pub container: Option<ContainerArg>,
 
     /// Treat input as a cubemap.
     #[arg(long)]

--- a/crates/ctt-cli/src/args.rs
+++ b/crates/ctt-cli/src/args.rs
@@ -40,9 +40,21 @@ pub struct Args {
     #[arg(long)]
     pub swizzle: Option<String>,
 
-    /// Color space of the input. Used for selecting output color space and performing mipmap generation.
-    #[arg(long, default_value = "srgb")]
-    pub color_space: ColorSpaceArg,
+    /// Color space of the input image(s).
+    #[arg(long, visible_alias = "ic", default_value = "srgb")]
+    pub input_color_space: ColorSpaceArg,
+
+    /// Alpha mode of the input image(s).
+    #[arg(long, visible_alias = "ia", default_value = "straight")]
+    pub input_alpha: AlphaModeArg,
+
+    /// Desired color space of the output. If omitted, matches the input.
+    #[arg(long, visible_alias = "oc")]
+    pub output_color_space: Option<ColorSpaceArg>,
+
+    /// Desired alpha mode of the output. If omitted, matches the input.
+    #[arg(long, visible_alias = "oa")]
+    pub output_alpha: Option<AlphaModeArg>,
 
     /// Compression quality preset.
     #[arg(long, default_value = "basic")]
@@ -85,6 +97,13 @@ pub enum CubemapLayoutArg {
 pub enum ColorSpaceArg {
     Srgb,
     Linear,
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum AlphaModeArg {
+    Straight,
+    Premultiplied,
+    Opaque,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/crates/ctt-cli/src/format.rs
+++ b/crates/ctt-cli/src/format.rs
@@ -1,0 +1,313 @@
+use ctt::encoder::EncoderRegistry;
+use ctt::error::Error;
+use ctt::ktx2;
+
+/// The result of parsing a `--format` string.
+pub enum ParsedFormat {
+    /// A block-compressed format, optionally with a specific encoder.
+    Compressed {
+        encoder_name: Option<String>,
+        format: ktx2::Format,
+    },
+    /// An uncompressed pixel format (e.g. `rgba8unorm`, `r16g16b16a16_sfloat`).
+    Uncompressed(ktx2::Format),
+}
+
+/// Parse a format string that may be compressed or uncompressed.
+///
+/// Compressed formats may have an encoder prefix (e.g. `intel_bc7`).
+/// Uncompressed formats accept both WebGPU-style (`rgba8unorm`) and Vulkan-style
+/// (`r8g8b8a8_unorm`) names.
+pub fn parse_format(s: &str, registry: &EncoderRegistry) -> Result<ParsedFormat, Error> {
+    let lower = s.to_lowercase();
+
+    // Try uncompressed first — these names never collide with encoder prefixes.
+    if let Some(format) = parse_uncompressed(&lower) {
+        return Ok(ParsedFormat::Uncompressed(format));
+    }
+
+    // Try encoder-prefixed compressed formats.
+    let mut prefixes: Vec<String> = registry
+        .encoders()
+        .iter()
+        .map(|e| e.name().to_string())
+        .collect();
+    prefixes.sort_by_key(|p| std::cmp::Reverse(p.len()));
+
+    for prefix in &prefixes {
+        if let Some(rest) = lower
+            .strip_prefix(prefix.as_str())
+            .and_then(|r| r.strip_prefix('_'))
+        {
+            let format = parse_compressed(rest, s)?;
+            return Ok(ParsedFormat::Compressed {
+                encoder_name: Some(prefix.to_string()),
+                format,
+            });
+        }
+    }
+
+    // Bare compressed format.
+    let format = parse_compressed(&lower, s)?;
+    Ok(ParsedFormat::Compressed {
+        encoder_name: None,
+        format,
+    })
+}
+
+/// Short display name for a compressed format (used in `--list-encoders`).
+pub fn format_short_name(format: ktx2::Format) -> String {
+    use ktx2::Format as F;
+    match format {
+        F::BC1_RGBA_UNORM_BLOCK | F::BC1_RGB_UNORM_BLOCK => "bc1".into(),
+        F::BC2_UNORM_BLOCK => "bc2".into(),
+        F::BC3_UNORM_BLOCK => "bc3".into(),
+        F::BC4_UNORM_BLOCK => "bc4".into(),
+        F::BC4_SNORM_BLOCK => "bc4s".into(),
+        F::BC5_UNORM_BLOCK => "bc5".into(),
+        F::BC5_SNORM_BLOCK => "bc5s".into(),
+        F::BC6H_UFLOAT_BLOCK => "bc6h".into(),
+        F::BC6H_SFLOAT_BLOCK => "bc6hsf".into(),
+        F::BC7_UNORM_BLOCK => "bc7".into(),
+        F::ETC2_R8G8B8_UNORM_BLOCK => "etc1".into(),
+        _ => format!("{format:?}").to_lowercase(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compressed format parsing
+// ---------------------------------------------------------------------------
+
+fn parse_compressed(lower: &str, original: &str) -> Result<ktx2::Format, Error> {
+    use ktx2::Format as F;
+    match lower {
+        "bc1" => Ok(F::BC1_RGBA_UNORM_BLOCK),
+        "bc2" => Ok(F::BC2_UNORM_BLOCK),
+        "bc3" => Ok(F::BC3_UNORM_BLOCK),
+        "bc4" => Ok(F::BC4_UNORM_BLOCK),
+        "bc4s" => Ok(F::BC4_SNORM_BLOCK),
+        "bc5" => Ok(F::BC5_UNORM_BLOCK),
+        "bc5s" => Ok(F::BC5_SNORM_BLOCK),
+        "bc6h" => Ok(F::BC6H_UFLOAT_BLOCK),
+        "bc6hsf" | "bc6h_sf" => Ok(F::BC6H_SFLOAT_BLOCK),
+        "bc7" => Ok(F::BC7_UNORM_BLOCK),
+        "etc1" => Ok(F::ETC2_R8G8B8_UNORM_BLOCK),
+        other => {
+            if let Some(rest) = other.strip_prefix("astc_") {
+                let (w, h) = rest
+                    .split_once('x')
+                    .ok_or_else(|| Error::UnsupportedFormat(original.into()))?;
+                let block_width: u8 = w
+                    .parse()
+                    .map_err(|_| Error::UnsupportedFormat(original.into()))?;
+                let block_height: u8 = h
+                    .parse()
+                    .map_err(|_| Error::UnsupportedFormat(original.into()))?;
+                astc_format(block_width, block_height)
+                    .ok_or_else(|| Error::UnsupportedFormat(original.into()))
+            } else {
+                Err(Error::UnsupportedFormat(original.into()))
+            }
+        }
+    }
+}
+
+fn astc_format(block_width: u8, block_height: u8) -> Option<ktx2::Format> {
+    use ktx2::Format as F;
+    Some(match (block_width, block_height) {
+        (4, 4) => F::ASTC_4x4_UNORM_BLOCK,
+        (5, 4) => F::ASTC_5x4_UNORM_BLOCK,
+        (5, 5) => F::ASTC_5x5_UNORM_BLOCK,
+        (6, 5) => F::ASTC_6x5_UNORM_BLOCK,
+        (6, 6) => F::ASTC_6x6_UNORM_BLOCK,
+        (8, 5) => F::ASTC_8x5_UNORM_BLOCK,
+        (8, 6) => F::ASTC_8x6_UNORM_BLOCK,
+        (8, 8) => F::ASTC_8x8_UNORM_BLOCK,
+        (10, 5) => F::ASTC_10x5_UNORM_BLOCK,
+        (10, 6) => F::ASTC_10x6_UNORM_BLOCK,
+        (10, 8) => F::ASTC_10x8_UNORM_BLOCK,
+        (10, 10) => F::ASTC_10x10_UNORM_BLOCK,
+        (12, 10) => F::ASTC_12x10_UNORM_BLOCK,
+        (12, 12) => F::ASTC_12x12_UNORM_BLOCK,
+        _ => return None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Uncompressed format parsing
+// ---------------------------------------------------------------------------
+
+/// Try to parse an uncompressed format name.
+///
+/// Each format accepts both WebGPU-style (`rgba8unorm`) and Vulkan-style (`r8g8b8a8_unorm`)
+/// names. Float suffixes (`float`, `sfloat`) map to SFLOAT. Integer type suffixes
+/// (`unorm`, `snorm`, `uint`, `sint`) must be specified explicitly.
+#[rustfmt::skip]
+fn parse_uncompressed(s: &str) -> Option<ktx2::Format> {
+    use ktx2::Format as F;
+
+    Some(match s {
+        // --- R8 ---
+        "r8unorm" | "r8_unorm" => F::R8_UNORM,
+        "r8snorm" | "r8_snorm" => F::R8_SNORM,
+        "r8uint" | "r8_uint" => F::R8_UINT,
+        "r8sint" | "r8_sint" => F::R8_SINT,
+
+        // --- RG8 ---
+        "rg8unorm" | "r8g8_unorm" => F::R8G8_UNORM,
+        "rg8snorm" | "r8g8_snorm" => F::R8G8_SNORM,
+        "rg8uint" | "r8g8_uint" => F::R8G8_UINT,
+        "rg8sint" | "r8g8_sint" => F::R8G8_SINT,
+
+        // --- RGBA8 ---
+        "rgba8unorm" | "r8g8b8a8_unorm" => F::R8G8B8A8_UNORM,
+        "rgba8snorm" | "r8g8b8a8_snorm" => F::R8G8B8A8_SNORM,
+        "rgba8uint" | "r8g8b8a8_uint" => F::R8G8B8A8_UINT,
+        "rgba8sint" | "r8g8b8a8_sint" => F::R8G8B8A8_SINT,
+
+        // --- BGRA8 ---
+        "bgra8unorm" | "b8g8r8a8_unorm" => F::B8G8R8A8_UNORM,
+        "bgra8snorm" | "b8g8r8a8_snorm" => F::B8G8R8A8_SNORM,
+        "bgra8uint" | "b8g8r8a8_uint" => F::B8G8R8A8_UINT,
+        "bgra8sint" | "b8g8r8a8_sint" => F::B8G8R8A8_SINT,
+
+        // --- R16 ---
+        "r16unorm" | "r16_unorm" => F::R16_UNORM,
+        "r16snorm" | "r16_snorm" => F::R16_SNORM,
+        "r16uint" | "r16_uint" => F::R16_UINT,
+        "r16sint" | "r16_sint" => F::R16_SINT,
+        "r16float" | "r16sfloat" | "r16_float" | "r16_sfloat" => F::R16_SFLOAT,
+
+        // --- RG16 ---
+        "rg16unorm" | "r16g16_unorm" => F::R16G16_UNORM,
+        "rg16snorm" | "r16g16_snorm" => F::R16G16_SNORM,
+        "rg16uint" | "r16g16_uint" => F::R16G16_UINT,
+        "rg16sint" | "r16g16_sint" => F::R16G16_SINT,
+        "rg16float" | "rg16sfloat" | "r16g16_float" | "r16g16_sfloat" => F::R16G16_SFLOAT,
+
+        // --- RGBA16 ---
+        "rgba16unorm" | "r16g16b16a16_unorm" => F::R16G16B16A16_UNORM,
+        "rgba16snorm" | "r16g16b16a16_snorm" => F::R16G16B16A16_SNORM,
+        "rgba16uint" | "r16g16b16a16_uint" => F::R16G16B16A16_UINT,
+        "rgba16sint" | "r16g16b16a16_sint" => F::R16G16B16A16_SINT,
+        "rgba16float" | "rgba16sfloat" | "r16g16b16a16_float" | "r16g16b16a16_sfloat" => F::R16G16B16A16_SFLOAT,
+
+        // --- R32 ---
+        "r32uint" | "r32_uint" => F::R32_UINT,
+        "r32sint" | "r32_sint" => F::R32_SINT,
+        "r32float" | "r32sfloat" | "r32_float" | "r32_sfloat" => F::R32_SFLOAT,
+
+        // --- RG32 ---
+        "rg32uint" | "r32g32_uint" => F::R32G32_UINT,
+        "rg32sint" | "r32g32_sint" => F::R32G32_SINT,
+        "rg32float" | "rg32sfloat" | "r32g32_float" | "r32g32_sfloat" => F::R32G32_SFLOAT,
+
+        // --- RGBA32 ---
+        "rgba32uint" | "r32g32b32a32_uint" => F::R32G32B32A32_UINT,
+        "rgba32sint" | "r32g32b32a32_sint" => F::R32G32B32A32_SINT,
+        "rgba32float" | "rgba32sfloat" | "r32g32b32a32_float" | "r32g32b32a32_sfloat" => F::R32G32B32A32_SFLOAT,
+
+        // --- Packed ---
+        "rg11b10ufloat" | "rg11b10float" | "b10g11r11_ufloat" | "b10g11r11_ufloat_pack32" => F::B10G11R11_UFLOAT_PACK32,
+
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ktx2::Format as F;
+
+    #[test]
+    fn webgpu_rgba8unorm() {
+        assert_eq!(parse_uncompressed("rgba8unorm"), Some(F::R8G8B8A8_UNORM));
+    }
+
+    #[test]
+    fn vulkan_r8g8b8a8_unorm() {
+        assert_eq!(
+            parse_uncompressed("r8g8b8a8_unorm"),
+            Some(F::R8G8B8A8_UNORM)
+        );
+    }
+
+    #[test]
+    fn webgpu_float_defaults_to_sfloat() {
+        assert_eq!(
+            parse_uncompressed("rgba16float"),
+            Some(F::R16G16B16A16_SFLOAT)
+        );
+        assert_eq!(parse_uncompressed("r32float"), Some(F::R32_SFLOAT));
+    }
+
+    #[test]
+    fn vulkan_float_defaults_to_sfloat() {
+        assert_eq!(
+            parse_uncompressed("r16g16b16a16_float"),
+            Some(F::R16G16B16A16_SFLOAT)
+        );
+        assert_eq!(parse_uncompressed("r32_float"), Some(F::R32_SFLOAT));
+    }
+
+    #[test]
+    fn webgpu_bgra() {
+        assert_eq!(parse_uncompressed("bgra8unorm"), Some(F::B8G8R8A8_UNORM));
+    }
+
+    #[test]
+    fn vulkan_bgra() {
+        assert_eq!(
+            parse_uncompressed("b8g8r8a8_unorm"),
+            Some(F::B8G8R8A8_UNORM)
+        );
+    }
+
+    #[test]
+    fn packed_rg11b10() {
+        assert_eq!(
+            parse_uncompressed("rg11b10ufloat"),
+            Some(F::B10G11R11_UFLOAT_PACK32)
+        );
+        assert_eq!(
+            parse_uncompressed("b10g11r11_ufloat"),
+            Some(F::B10G11R11_UFLOAT_PACK32)
+        );
+    }
+
+    #[test]
+    fn bare_name_without_type_is_not_uncompressed() {
+        assert_eq!(parse_uncompressed("rgba8"), None);
+        assert_eq!(parse_uncompressed("r16"), None);
+    }
+
+    #[test]
+    fn compressed_not_parsed_as_uncompressed() {
+        assert_eq!(parse_uncompressed("bc7"), None);
+        assert_eq!(parse_uncompressed("astc_4x4"), None);
+    }
+
+    #[test]
+    fn parse_format_uncompressed() {
+        let registry = EncoderRegistry::default_registry();
+        match parse_format("rgba8unorm", &registry).unwrap() {
+            ParsedFormat::Uncompressed(f) => assert_eq!(f, F::R8G8B8A8_UNORM),
+            _ => panic!("expected uncompressed"),
+        }
+    }
+
+    #[test]
+    fn parse_format_compressed() {
+        let registry = EncoderRegistry::default_registry();
+        match parse_format("bc7", &registry).unwrap() {
+            ParsedFormat::Compressed {
+                encoder_name,
+                format,
+            } => {
+                assert_eq!(encoder_name, None);
+                assert_eq!(format, F::BC7_UNORM_BLOCK);
+            }
+            _ => panic!("expected compressed"),
+        }
+    }
+}

--- a/crates/ctt-cli/src/main.rs
+++ b/crates/ctt-cli/src/main.rs
@@ -13,9 +13,9 @@ use ctt::error::Error;
 use ctt::pipeline::{AssemblyNode, InputBranch, InputNode, OutputNode, Pipeline, PipelineOutput};
 use ctt::surface::{ColorSpace, Image, Surface};
 use ctt::transforms::compress::CompressTransform;
+use ctt::transforms::output_state::OutputStateTransform;
 use ctt::transforms::swizzle::SwizzleTransform;
 use ctt::transforms::swizzle::{Swizzle, SwizzleChannel};
-use ctt::transforms::output_state::OutputStateTransform;
 use ctt::vk_format::FormatExt;
 
 use args::{AlphaModeArg, Args, ColorSpaceArg, ContainerArg, CubemapLayoutArg, QualityArg};

--- a/crates/ctt-cli/src/main.rs
+++ b/crates/ctt-cli/src/main.rs
@@ -81,7 +81,8 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
     let surfaces = load_images(&args.input, color_space)?;
 
     let display_format = match &parsed_format {
-        Some(ParsedFormat::Compressed { format, .. }) | Some(ParsedFormat::Uncompressed(format)) => *format,
+        Some(ParsedFormat::Compressed { format, .. })
+        | Some(ParsedFormat::Uncompressed(format)) => *format,
         None => surfaces[0].format,
     };
     match &parsed_format {

--- a/crates/ctt-cli/src/main.rs
+++ b/crates/ctt-cli/src/main.rs
@@ -15,10 +15,10 @@ use ctt::surface::{ColorSpace, Image, Surface};
 use ctt::transforms::compress::CompressTransform;
 use ctt::transforms::swizzle::SwizzleTransform;
 use ctt::transforms::swizzle::{Swizzle, SwizzleChannel};
-use ctt::transforms::target_format::TargetFormatTransform;
+use ctt::transforms::output_state::OutputStateTransform;
 use ctt::vk_format::FormatExt;
 
-use args::{Args, ColorSpaceArg, ContainerArg, CubemapLayoutArg, QualityArg};
+use args::{AlphaModeArg, Args, ColorSpaceArg, ContainerArg, CubemapLayoutArg, QualityArg};
 use format::{ParsedFormat, format_short_name, parse_format};
 
 fn main() -> ExitCode {
@@ -61,10 +61,10 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
 
     let output = args.output.as_ref().unwrap();
 
-    let color_space = match args.color_space {
-        ColorSpaceArg::Srgb => ColorSpace::Srgb,
-        ColorSpaceArg::Linear => ColorSpace::Linear,
-    };
+    let input_color_space = map_color_space(args.input_color_space);
+    let input_alpha = map_alpha_mode(args.input_alpha);
+    let output_color_space = args.output_color_space.map(map_color_space);
+    let output_alpha = args.output_alpha.map(map_alpha_mode);
 
     let parsed_format = args
         .format
@@ -78,7 +78,7 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
 
     // Load input images.
     log::info!("Loading {} input image(s)", args.input.len());
-    let surfaces = load_images(&args.input, color_space)?;
+    let surfaces = load_images(&args.input, input_color_space, input_alpha)?;
 
     let display_format = match &parsed_format {
         Some(ParsedFormat::Compressed { format, .. })
@@ -88,12 +88,12 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
     match &parsed_format {
         Some(ParsedFormat::Compressed { .. }) => {
             log::info!(
-                "Format: {display_format:?}, container: {output_node:?}, quality: {quality:?}, color space: {color_space:?}",
+                "Format: {display_format:?}, container: {output_node:?}, quality: {quality:?}, color space: {input_color_space:?}, alpha: {input_alpha:?}",
             );
         }
         _ => {
             log::info!(
-                "Format: {display_format:?}, container: {output_node:?}, color space: {color_space:?}",
+                "Format: {display_format:?}, container: {output_node:?}, color space: {input_color_space:?}, alpha: {input_alpha:?}",
             );
         }
     }
@@ -134,6 +134,15 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
             encoder_name,
             format: target_format,
         }) => {
+            // Insert output state before compression so the data is in the
+            // desired color space / alpha mode when it reaches the encoder.
+            if output_color_space.is_some() || output_alpha.is_some() {
+                transforms.push(Box::new(OutputStateTransform::new(
+                    None,
+                    output_color_space,
+                    output_alpha,
+                )));
+            }
             let encoder_settings = build_encoder_settings(args);
             transforms.push(Box::new(CompressTransform::new(
                 target_format,
@@ -144,10 +153,22 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
             )));
         }
         Some(ParsedFormat::Uncompressed(target_format)) => {
-            transforms.push(Box::new(TargetFormatTransform::new(target_format)));
+            transforms.push(Box::new(OutputStateTransform::new(
+                Some(target_format),
+                output_color_space,
+                output_alpha,
+            )));
         }
         None => {
-            // Passthrough — no format transforms.
+            // Only insert an output state transform if the user requested a
+            // specific output color space or alpha mode.
+            if output_color_space.is_some() || output_alpha.is_some() {
+                transforms.push(Box::new(OutputStateTransform::new(
+                    None,
+                    output_color_space,
+                    output_alpha,
+                )));
+            }
         }
     }
 
@@ -292,6 +313,7 @@ fn print_encoder_table(registry: &EncoderRegistry) {
 fn load_images(
     paths: &[std::path::PathBuf],
     color_space: ColorSpace,
+    alpha: ctt::alpha::AlphaMode,
 ) -> Result<Vec<Surface>, Box<dyn std::error::Error>> {
     let mut surfaces = Vec::with_capacity(paths.len());
     for path in paths {
@@ -309,7 +331,7 @@ fn load_images(
                     stride,
                     format: ctt::ktx2::Format::R32G32B32A32_SFLOAT,
                     color_space,
-                    alpha: ctt::alpha::AlphaMode::Straight,
+                    alpha,
                 }
             }
             image::ColorType::Rgb16 | image::ColorType::Rgba16 => {
@@ -323,7 +345,7 @@ fn load_images(
                     stride,
                     format: ctt::ktx2::Format::R16G16B16A16_UNORM,
                     color_space,
-                    alpha: ctt::alpha::AlphaMode::Straight,
+                    alpha,
                 }
             }
             _ => {
@@ -337,7 +359,7 @@ fn load_images(
                     stride,
                     format: ctt::ktx2::Format::R8G8B8A8_UNORM,
                     color_space,
-                    alpha: ctt::alpha::AlphaMode::Straight,
+                    alpha,
                 }
             }
         };
@@ -407,6 +429,21 @@ fn build_encoder_settings(args: &Args) -> Option<Box<dyn ctt::encoder::EncoderSe
         return Some(Box::new(ctt::encoders::ispc::IspcSettings { alpha: true }));
     }
     None
+}
+
+fn map_color_space(cs: ColorSpaceArg) -> ColorSpace {
+    match cs {
+        ColorSpaceArg::Srgb => ColorSpace::Srgb,
+        ColorSpaceArg::Linear => ColorSpace::Linear,
+    }
+}
+
+fn map_alpha_mode(a: AlphaModeArg) -> ctt::alpha::AlphaMode {
+    match a {
+        AlphaModeArg::Straight => ctt::alpha::AlphaMode::Straight,
+        AlphaModeArg::Premultiplied => ctt::alpha::AlphaMode::Premultiplied,
+        AlphaModeArg::Opaque => ctt::alpha::AlphaMode::Opaque,
+    }
 }
 
 fn parse_swizzle(s: &str) -> Result<Swizzle, Error> {

--- a/crates/ctt-cli/src/main.rs
+++ b/crates/ctt-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod args;
+mod format;
 
 use std::fs;
 use std::process::ExitCode;
@@ -14,9 +15,11 @@ use ctt::surface::{ColorSpace, Image, Surface};
 use ctt::transforms::compress::CompressTransform;
 use ctt::transforms::swizzle::SwizzleTransform;
 use ctt::transforms::swizzle::{Swizzle, SwizzleChannel};
+use ctt::transforms::target_format::TargetFormatTransform;
 use ctt::vk_format::FormatExt;
 
 use args::{Args, ColorSpaceArg, ContainerArg, CubemapLayoutArg, QualityArg};
+use format::{ParsedFormat, format_short_name, parse_format};
 
 fn main() -> ExitCode {
     let args = Args::parse();
@@ -56,7 +59,6 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let format_str = args.format.as_deref().unwrap();
     let output = args.output.as_ref().unwrap();
 
     let color_space = match args.color_space {
@@ -64,21 +66,36 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         ColorSpaceArg::Linear => ColorSpace::Linear,
     };
 
-    let (encoder_name, target_format) = parse_format(format_str, &registry)?;
-    let output_node = match args.container {
-        ContainerArg::Dds => OutputNode::Dds,
-        ContainerArg::Ktx2 => OutputNode::Ktx2,
-    };
+    let parsed_format = args
+        .format
+        .as_deref()
+        .map(|s| parse_format(s, &registry))
+        .transpose()?;
+
+    let output_node = resolve_container(args.container, output)?;
     let swizzle = args.swizzle.as_deref().map(parse_swizzle).transpose()?;
     let quality = map_quality(args.quality);
-
-    log::info!(
-        "Format: {target_format:?}, container: {output_node:?}, quality: {quality:?}, color space: {color_space:?}",
-    );
 
     // Load input images.
     log::info!("Loading {} input image(s)", args.input.len());
     let surfaces = load_images(&args.input, color_space)?;
+
+    let display_format = match &parsed_format {
+        Some(ParsedFormat::Compressed { format, .. }) | Some(ParsedFormat::Uncompressed(format)) => *format,
+        None => surfaces[0].format,
+    };
+    match &parsed_format {
+        Some(ParsedFormat::Compressed { .. }) => {
+            log::info!(
+                "Format: {display_format:?}, container: {output_node:?}, quality: {quality:?}, color space: {color_space:?}",
+            );
+        }
+        _ => {
+            log::info!(
+                "Format: {display_format:?}, container: {output_node:?}, color space: {color_space:?}",
+            );
+        }
+    }
 
     // Build input branches and assembly.
     let (inputs, assembly) = if args.cubemap {
@@ -111,14 +128,27 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         transforms.push(Box::new(SwizzleTransform::new(*swizzle)));
     }
 
-    let encoder_settings = build_encoder_settings(args);
-    transforms.push(Box::new(CompressTransform::new(
-        target_format,
-        quality,
-        encoder_name,
-        encoder_settings,
-        Arc::clone(&registry),
-    )));
+    match parsed_format {
+        Some(ParsedFormat::Compressed {
+            encoder_name,
+            format: target_format,
+        }) => {
+            let encoder_settings = build_encoder_settings(args);
+            transforms.push(Box::new(CompressTransform::new(
+                target_format,
+                quality,
+                encoder_name,
+                encoder_settings,
+                Arc::clone(&registry),
+            )));
+        }
+        Some(ParsedFormat::Uncompressed(target_format)) => {
+            transforms.push(Box::new(TargetFormatTransform::new(target_format)));
+        }
+        None => {
+            // Passthrough — no format transforms.
+        }
+    }
 
     let pipeline = Pipeline {
         inputs,
@@ -149,6 +179,35 @@ fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         output_bytes.len()
     );
     Ok(())
+}
+
+/// Resolve the container format from the explicit flag or the output file extension.
+fn resolve_container(
+    explicit: Option<ContainerArg>,
+    output: &std::path::Path,
+) -> Result<OutputNode, Error> {
+    if let Some(container) = explicit {
+        return Ok(match container {
+            ContainerArg::Dds => OutputNode::Dds,
+            ContainerArg::Ktx2 => OutputNode::Ktx2,
+        });
+    }
+
+    let ext = output
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase());
+
+    match ext.as_deref() {
+        Some("dds") => Ok(OutputNode::Dds),
+        Some("ktx2") => Ok(OutputNode::Ktx2),
+        Some(other) => Err(Error::UnsupportedFormat(format!(
+            "cannot infer container from extension '.{other}'; use --container or a .dds/.ktx2 extension"
+        ))),
+        None => Err(Error::UnsupportedFormat(
+            "output path has no extension; use --container or a .dds/.ktx2 extension".into(),
+        )),
+    }
 }
 
 fn print_encoder_table(registry: &EncoderRegistry) {
@@ -226,25 +285,7 @@ fn print_encoder_table(registry: &EncoderRegistry) {
     println!("Use a bare format name (e.g. bc7) to use the highest-priority encoder,");
     println!("or prefix with the encoder name (e.g. intel_bc7) to choose explicitly.");
     println!("ASTC formats use astc_WxH (e.g. astc_4x4, astc_8x8, astc_12x12).");
-}
-
-/// Short display name for a compressed format.
-fn format_short_name(format: ctt::ktx2::Format) -> String {
-    use ctt::ktx2::Format as F;
-    match format {
-        F::BC1_RGBA_UNORM_BLOCK | F::BC1_RGB_UNORM_BLOCK => "bc1".into(),
-        F::BC2_UNORM_BLOCK => "bc2".into(),
-        F::BC3_UNORM_BLOCK => "bc3".into(),
-        F::BC4_UNORM_BLOCK => "bc4".into(),
-        F::BC4_SNORM_BLOCK => "bc4s".into(),
-        F::BC5_UNORM_BLOCK => "bc5".into(),
-        F::BC5_SNORM_BLOCK => "bc5s".into(),
-        F::BC6H_UFLOAT_BLOCK => "bc6h".into(),
-        F::BC6H_SFLOAT_BLOCK => "bc6hsf".into(),
-        F::BC7_UNORM_BLOCK => "bc7".into(),
-        F::ETC2_R8G8B8_UNORM_BLOCK => "etc1".into(),
-        _ => format!("{format:?}").to_lowercase(),
-    }
+    println!("Uncompressed formats use WebGPU (rgba8unorm) or Vulkan (r8g8b8a8_unorm) names.");
 }
 
 fn load_images(
@@ -365,94 +406,6 @@ fn build_encoder_settings(args: &Args) -> Option<Box<dyn ctt::encoder::EncoderSe
         return Some(Box::new(ctt::encoders::ispc::IspcSettings { alpha: true }));
     }
     None
-}
-
-/// Parse a format string, optionally with an encoder prefix (e.g., "intel_bc7", "bc7e_bc7").
-///
-/// Returns `(optional_encoder_name, target_ktx2_format)`.
-fn parse_format(
-    s: &str,
-    registry: &EncoderRegistry,
-) -> Result<(Option<String>, ctt::ktx2::Format), Error> {
-    let lower = s.to_lowercase();
-
-    // Derive encoder prefixes from the registry, sorted longest-first
-    // so that longer names match before shorter ones (e.g. "astcenc" before "astc").
-    let mut prefixes: Vec<String> = registry
-        .encoders()
-        .iter()
-        .map(|e| e.name().to_string())
-        .collect();
-    prefixes.sort_by_key(|p| std::cmp::Reverse(p.len()));
-
-    for prefix in &prefixes {
-        if let Some(rest) = lower
-            .strip_prefix(prefix.as_str())
-            .and_then(|r| r.strip_prefix('_'))
-        {
-            let format = parse_bare_format(rest, s)?;
-            return Ok((Some(prefix.to_string()), format));
-        }
-    }
-
-    // No prefix — parse as bare format.
-    let format = parse_bare_format(&lower, s)?;
-    Ok((None, format))
-}
-
-fn parse_bare_format(lower: &str, original: &str) -> Result<ctt::ktx2::Format, Error> {
-    use ctt::ktx2::Format as F;
-    match lower {
-        "bc1" => Ok(F::BC1_RGBA_UNORM_BLOCK),
-        "bc2" => Ok(F::BC2_UNORM_BLOCK),
-        "bc3" => Ok(F::BC3_UNORM_BLOCK),
-        "bc4" => Ok(F::BC4_UNORM_BLOCK),
-        "bc4s" => Ok(F::BC4_SNORM_BLOCK),
-        "bc5" => Ok(F::BC5_UNORM_BLOCK),
-        "bc5s" => Ok(F::BC5_SNORM_BLOCK),
-        "bc6h" => Ok(F::BC6H_UFLOAT_BLOCK),
-        "bc6hsf" | "bc6h_sf" => Ok(F::BC6H_SFLOAT_BLOCK),
-        "bc7" => Ok(F::BC7_UNORM_BLOCK),
-        "etc1" => Ok(F::ETC2_R8G8B8_UNORM_BLOCK),
-        other => {
-            if let Some(rest) = other.strip_prefix("astc_") {
-                let (w, h) = rest
-                    .split_once('x')
-                    .ok_or_else(|| Error::UnsupportedFormat(original.into()))?;
-                let block_width: u8 = w
-                    .parse()
-                    .map_err(|_| Error::UnsupportedFormat(original.into()))?;
-                let block_height: u8 = h
-                    .parse()
-                    .map_err(|_| Error::UnsupportedFormat(original.into()))?;
-                astc_format(block_width, block_height)
-                    .ok_or_else(|| Error::UnsupportedFormat(original.into()))
-            } else {
-                Err(Error::UnsupportedFormat(original.into()))
-            }
-        }
-    }
-}
-
-fn astc_format(block_width: u8, block_height: u8) -> Option<ctt::ktx2::Format> {
-    use ctt::ktx2::Format as F;
-    Some(match (block_width, block_height) {
-        (4, 4) => F::ASTC_4x4_UNORM_BLOCK,
-        (5, 4) => F::ASTC_5x4_UNORM_BLOCK,
-        (5, 5) => F::ASTC_5x5_UNORM_BLOCK,
-        (6, 5) => F::ASTC_6x5_UNORM_BLOCK,
-        (6, 6) => F::ASTC_6x6_UNORM_BLOCK,
-        (8, 5) => F::ASTC_8x5_UNORM_BLOCK,
-        (8, 6) => F::ASTC_8x6_UNORM_BLOCK,
-        (8, 8) => F::ASTC_8x8_UNORM_BLOCK,
-        (10, 5) => F::ASTC_10x5_UNORM_BLOCK,
-        (10, 6) => F::ASTC_10x6_UNORM_BLOCK,
-        (10, 8) => F::ASTC_10x8_UNORM_BLOCK,
-        (10, 10) => F::ASTC_10x10_UNORM_BLOCK,
-        (12, 10) => F::ASTC_12x10_UNORM_BLOCK,
-        (12, 12) => F::ASTC_12x12_UNORM_BLOCK,
-        _ => return None,
-    })
 }
 
 fn parse_swizzle(s: &str) -> Result<Swizzle, Error> {

--- a/crates/ctt-intel-texture-compressor/src/bc6h.rs
+++ b/crates/ctt-intel-texture-compressor/src/bc6h.rs
@@ -1,20 +1,11 @@
-//! BC6H block compression — RGB HDR (unsigned 16-bit).
+//! BC6H block compression — RGB HDR (half-precision float).
 //!
 //! # Input format
 //!
-//! Expects an [`Rgba16Surface`] with **`R16 G16 B16 A16` interleaved** pixel
-//! data (8 bytes per pixel). Each channel is a **little-endian unsigned 16-bit
-//! integer** (u16) in the range `0..=65535`. The alpha channel is present in
-//! the layout but **ignored** by the encoder (it is set to zero internally).
-//!
-//! The ISPC kernel reads each channel with 2-byte offsets from the row base
-//! pointer and masks to 16 bits (`& 0xFFFF`). The quantization path normalizes
-//! against `65535` (`256² − 1`), confirming a full u16 value range.
-//!
-//! **Note:** despite the name "half-float" often associated with BC6H, this
-//! encoder takes raw u16 values, not IEEE 754 binary16 (half-precision)
-//! floats. Callers that have f16 data should transmute / bitcast their
-//! half-float bits into u16 before passing them in.
+//! Expects an [`RgbaF16Surface`] with **`R16 G16 B16 A16` interleaved** pixel
+//! data (8 bytes per pixel). Each channel is a **little-endian IEEE 754
+//! binary16 (half-precision) float**. The alpha channel is present in the
+//! layout but **ignored** by the encoder (it is set to zero internally).
 //!
 //! # Output
 //!
@@ -22,7 +13,7 @@
 //! format stores unsigned half-float endpoints; signed BC6H is not supported
 //! by this encoder.
 
-use crate::Rgba16Surface;
+use crate::RgbaF16Surface;
 use crate::bindings::kernel;
 
 #[derive(Debug, Copy, Clone)]
@@ -42,24 +33,24 @@ pub fn calc_output_size(width: u32, height: u32) -> usize {
 }
 
 #[must_use]
-pub fn compress_blocks(settings: &EncodeSettings, surface: &Rgba16Surface) -> Vec<u8> {
+pub fn compress_blocks(settings: &EncodeSettings, surface: &RgbaF16Surface) -> Vec<u8> {
     let output_size = calc_output_size(surface.width, surface.height);
     let mut output = vec![0u8; output_size];
     compress_blocks_into(settings, surface, &mut output);
     output
 }
 
-/// Compresses an [`Rgba16Surface`] into BC6H blocks.
+/// Compresses an [`RgbaF16Surface`] into BC6H blocks.
 ///
 /// The surface must contain `R16 G16 B16 A16` interleaved pixel data (8 bytes
-/// per pixel) where each channel is a little-endian u16. Only the R, G, and B
+/// per pixel) where each channel is a little-endian f16. Only the R, G, and B
 /// channels are encoded; the alpha channel is ignored.
 ///
 /// # Panics
 ///
 /// Panics if `blocks.len()` does not equal [`calc_output_size`] for the given
 /// surface dimensions.
-pub fn compress_blocks_into(settings: &EncodeSettings, surface: &Rgba16Surface, blocks: &mut [u8]) {
+pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaF16Surface, blocks: &mut [u8]) {
     assert_eq!(
         blocks.len(),
         calc_output_size(surface.width, surface.height)

--- a/crates/ctt-intel-texture-compressor/src/bc6h.rs
+++ b/crates/ctt-intel-texture-compressor/src/bc6h.rs
@@ -50,7 +50,11 @@ pub fn compress_blocks(settings: &EncodeSettings, surface: &RgbaF16Surface) -> V
 ///
 /// Panics if `blocks.len()` does not equal [`calc_output_size`] for the given
 /// surface dimensions.
-pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaF16Surface, blocks: &mut [u8]) {
+pub fn compress_blocks_into(
+    settings: &EncodeSettings,
+    surface: &RgbaF16Surface,
+    blocks: &mut [u8],
+) {
     assert_eq!(
         blocks.len(),
         calc_output_size(surface.width, surface.height)

--- a/crates/ctt-intel-texture-compressor/src/lib.rs
+++ b/crates/ctt-intel-texture-compressor/src/lib.rs
@@ -26,14 +26,14 @@ pub mod etc1;
 /// | [`RSurface`] | 1 | `R8` (1 byte/pixel) | [`bc4`] |
 /// | [`RgSurface`] | 2 | `R8 G8` interleaved (2 bytes/pixel) | [`bc5`] |
 /// | [`RgbaSurface`] | 4 | `R8 G8 B8 A8` interleaved (4 bytes/pixel) | [`bc1`], [`bc3`], [`bc7`], [`etc1`] |
-/// | [`Rgba16Surface`] | 8 | `R16 G16 B16 A16` interleaved (8 bytes/pixel) | [`bc6h`] |
+/// | [`RgbaF16Surface`] | 8 | `R16 G16 B16 A16` interleaved (8 bytes/pixel) | [`bc6h`] |
 #[derive(Debug, Copy, Clone)]
 pub struct Surface<'a, const COMPONENTS: usize> {
     /// The raw pixel data for the image.
     ///
     /// The byte interpretation depends on the encoder that consumes this
     /// surface. For most formats, each byte is one u8 channel sample. For
-    /// [`bc6h`], every two bytes form a little-endian u16 channel sample.
+    /// [`bc6h`], every two bytes form a little-endian f16 channel sample.
     ///
     /// The data does not need to be tightly packed, but if it isn't, `stride`
     /// must differ from `width * COMPONENTS`.
@@ -114,7 +114,6 @@ pub type RSurface<'a> = Surface<'a, 1>;
 
 /// 4-channel, 16-bit surface: `R16 G16 B16 A16` — 8 bytes per pixel.
 ///
-/// Each channel is a little-endian unsigned 16-bit integer (u16) in the range
-/// `0..=65535`. The alpha channel is present in the layout but ignored by
-/// [`bc6h`].
-pub type Rgba16Surface<'a> = Surface<'a, 8>;
+/// Each channel is a little-endian IEEE 754 binary16 (half-precision) float.
+/// The alpha channel is present in the layout but ignored by [`bc6h`].
+pub type RgbaF16Surface<'a> = Surface<'a, 8>;

--- a/crates/ctt/src/conversion_graph.rs
+++ b/crates/ctt/src/conversion_graph.rs
@@ -258,7 +258,22 @@ impl ConversionGraph {
         from: FormatState,
         constraint: &FormatConstraint,
     ) -> Option<Vec<FormatState>> {
-        if from.satisfies(constraint) {
+        // A goal state must satisfy the constraint AND preserve any properties
+        // that the constraint leaves unconstrained (color space, alpha mode).
+        let is_goal = |state: &FormatState| -> bool {
+            if !state.satisfies(constraint) {
+                return false;
+            }
+            if constraint.color_spaces.is_none() && state.color_space != from.color_space {
+                return false;
+            }
+            if constraint.alpha_modes.is_none() && state.alpha != from.alpha {
+                return false;
+            }
+            true
+        };
+
+        if is_goal(&from) {
             return Some(Vec::new());
         }
 
@@ -270,7 +285,7 @@ impl ConversionGraph {
         heap.push(Reverse((0, from)));
 
         while let Some(Reverse((cost, state))) = heap.pop() {
-            if state != from && state.satisfies(constraint) {
+            if state != from && is_goal(&state) {
                 return Some(Self::reconstruct_path(&prev, from, state));
             }
 
@@ -474,32 +489,42 @@ fn srgb_oetf(c: f64) -> f64 {
     }
 }
 
-/// Convert a surface from sRGB u8 unorm to linear f32.
+/// Convert a surface from sRGB to linear.
 ///
-/// RGB channels get the sRGB EOTF applied; alpha (if present) is treated as already linear
-/// and is just rescaled.
+/// Reads from any format and writes to the given target format.
+/// RGB channels get the sRGB EOTF applied; alpha (if present) is treated as already linear.
 fn srgb_to_linear(surface: &Surface, target: ktx2::Format, has_alpha: bool) -> Result<Surface> {
     let src_cc = surface
         .format
         .channel_count()
         .expect("unknown src channel count");
+    let src_ck = surface
+        .format
+        .channel_kind()
+        .expect("unknown src channel kind");
+    let src_cs = src_ck.byte_size();
+    let src_bpp = src_cc * src_cs;
+
     let dst_cc = target.channel_count().expect("unknown dst channel count");
+    let dst_ck = target.channel_kind().expect("unknown dst channel kind");
+    let dst_cs = dst_ck.byte_size();
+    let dst_bpp = dst_cc * dst_cs;
 
     let width = surface.width as usize;
     let height = surface.height as usize;
     let src_stride = surface.stride as usize;
-    let dst_stride = width * dst_cc * 4; // f32 = 4 bytes
+    let dst_stride = width * dst_bpp;
 
     let mut out = vec![0u8; dst_stride * height];
 
     for y in 0..height {
         for x in 0..width {
-            let src_off = y * src_stride + x * src_cc;
-            let dst_off = y * dst_stride + x * dst_cc * 4;
+            let src_off = y * src_stride + x * src_bpp;
+            let dst_off = y * dst_stride + x * dst_bpp;
 
             for ch in 0..dst_cc {
                 let val = if ch < src_cc {
-                    let raw = surface.data[src_off + ch] as f64 / 255.0;
+                    let raw = read_channel(&surface.data, src_off + ch * src_cs, src_ck);
                     if has_alpha && ch == 3 {
                         raw // alpha is linear
                     } else {
@@ -511,9 +536,7 @@ fn srgb_to_linear(surface: &Surface, target: ktx2::Format, has_alpha: bool) -> R
                     0.0
                 };
 
-                let v = val as f32;
-                let off = dst_off + ch * 4;
-                out[off..off + 4].copy_from_slice(&v.to_le_bytes());
+                write_channel(&mut out, dst_off + ch * dst_cs, dst_ck, val);
             }
         }
     }
@@ -529,39 +552,42 @@ fn srgb_to_linear(surface: &Surface, target: ktx2::Format, has_alpha: bool) -> R
     })
 }
 
-/// Convert a surface from linear f32 to sRGB u8 unorm.
+/// Convert a surface from linear to sRGB.
 ///
-/// RGB channels get the inverse sRGB EOTF applied; alpha (if present) is treated as linear
-/// and is just rescaled.
+/// Reads from any format and writes to the given target format.
+/// RGB channels get the inverse sRGB EOTF applied; alpha (if present) is treated as linear.
 fn linear_to_srgb(surface: &Surface, target: ktx2::Format, has_alpha: bool) -> Result<Surface> {
     let src_cc = surface
         .format
         .channel_count()
         .expect("unknown src channel count");
+    let src_ck = surface
+        .format
+        .channel_kind()
+        .expect("unknown src channel kind");
+    let src_cs = src_ck.byte_size();
+    let src_bpp = src_cc * src_cs;
+
     let dst_cc = target.channel_count().expect("unknown dst channel count");
+    let dst_ck = target.channel_kind().expect("unknown dst channel kind");
+    let dst_cs = dst_ck.byte_size();
+    let dst_bpp = dst_cc * dst_cs;
 
     let width = surface.width as usize;
     let height = surface.height as usize;
     let src_stride = surface.stride as usize;
-    let dst_stride = width * dst_cc; // u8 = 1 byte
+    let dst_stride = width * dst_bpp;
 
     let mut out = vec![0u8; dst_stride * height];
 
     for y in 0..height {
         for x in 0..width {
-            let src_off = y * src_stride + x * src_cc * 4;
-            let dst_off = y * dst_stride + x * dst_cc;
+            let src_off = y * src_stride + x * src_bpp;
+            let dst_off = y * dst_stride + x * dst_bpp;
 
             for ch in 0..dst_cc {
                 let linear = if ch < src_cc {
-                    let off = src_off + ch * 4;
-                    let bytes = [
-                        surface.data[off],
-                        surface.data[off + 1],
-                        surface.data[off + 2],
-                        surface.data[off + 3],
-                    ];
-                    f32::from_le_bytes(bytes) as f64
+                    read_channel(&surface.data, src_off + ch * src_cs, src_ck)
                 } else if ch == 3 {
                     1.0
                 } else {
@@ -574,7 +600,7 @@ fn linear_to_srgb(surface: &Surface, target: ktx2::Format, has_alpha: bool) -> R
                     srgb_oetf(linear)
                 };
 
-                out[dst_off + ch] = (encoded.clamp(0.0, 1.0) * 255.0).round() as u8;
+                write_channel(&mut out, dst_off + ch * dst_cs, dst_ck, encoded);
             }
         }
     }
@@ -724,12 +750,28 @@ pub fn build_default_graph() -> ConversionGraph {
         }
     }
 
-    // sRGB ↔ linear exact edges (u8 unorm srgb ↔ f32 linear, alpha stays linear).
-    let srgb_pairs = [
-        (F::R8_UNORM, F::R32_SFLOAT),
-        (F::R8G8_UNORM, F::R32G32_SFLOAT),
-        (F::R8G8B8_UNORM, F::R32G32B32_SFLOAT),
-        (F::R8G8B8A8_UNORM, F::R32G32B32A32_SFLOAT),
+    // sRGB ↔ linear exact edges.
+    //
+    // All edges go through F32: (any_fmt, sRGB) → (f32_fmt, Linear) and
+    // (f32_fmt, Linear) → (any_fmt, sRGB). This keeps the edge count manageable
+    // while supporting all format combinations via the graph.
+    let srgb_groups: &[(&[ktx2::Format], ktx2::Format)] = &[
+        (
+            &[F::R8_UNORM, F::R16_UNORM, F::R16_SFLOAT, F::R32_SFLOAT],
+            F::R32_SFLOAT,
+        ),
+        (
+            &[F::R8G8_UNORM, F::R16G16_UNORM, F::R16G16_SFLOAT, F::R32G32_SFLOAT],
+            F::R32G32_SFLOAT,
+        ),
+        (
+            &[F::R8G8B8_UNORM, F::R16G16B16_UNORM, F::R16G16B16_SFLOAT, F::R32G32B32_SFLOAT],
+            F::R32G32B32_SFLOAT,
+        ),
+        (
+            &[F::R8G8B8A8_UNORM, F::R16G16B16A16_UNORM, F::R16G16B16A16_SFLOAT, F::R32G32B32A32_SFLOAT],
+            F::R32G32B32A32_SFLOAT,
+        ),
     ];
 
     for alpha in [
@@ -737,39 +779,45 @@ pub fn build_default_graph() -> ConversionGraph {
         AlphaMode::Premultiplied,
         AlphaMode::Opaque,
     ] {
-        for &(u8_fmt, f32_fmt) in &srgb_pairs {
-            let has_alpha = u8_fmt.channel_count().unwrap_or(0) == 4;
+        for (fmts, f32_fmt) in srgb_groups {
+            let has_alpha = f32_fmt.channel_count().unwrap_or(0) == 4;
+            let f32_fmt = *f32_fmt;
 
-            // sRGB u8 → linear f32
-            {
-                let from = FormatState::new(u8_fmt, ColorSpace::Srgb, alpha);
-                let to = FormatState::new(f32_fmt, ColorSpace::Linear, alpha);
-                let converter: SurfaceConverter =
-                    Arc::new(move |surface: &Surface| srgb_to_linear(surface, f32_fmt, has_alpha));
-                graph.add_exact_edge(
-                    from,
-                    ExactEdge {
-                        target: to,
-                        cost: 10,
-                        converter,
-                    },
-                );
-            }
+            for &src_fmt in *fmts {
+                let cost = conversion_cost(src_fmt, f32_fmt).saturating_sub(5);
 
-            // linear f32 → sRGB u8
-            {
-                let from = FormatState::new(f32_fmt, ColorSpace::Linear, alpha);
-                let to = FormatState::new(u8_fmt, ColorSpace::Srgb, alpha);
-                let converter: SurfaceConverter =
-                    Arc::new(move |surface: &Surface| linear_to_srgb(surface, u8_fmt, has_alpha));
-                graph.add_exact_edge(
-                    from,
-                    ExactEdge {
-                        target: to,
-                        cost: 10,
-                        converter,
-                    },
-                );
+                // sRGB src → linear f32
+                {
+                    let from = FormatState::new(src_fmt, ColorSpace::Srgb, alpha);
+                    let to = FormatState::new(f32_fmt, ColorSpace::Linear, alpha);
+                    let converter: SurfaceConverter =
+                        Arc::new(move |surface: &Surface| srgb_to_linear(surface, f32_fmt, has_alpha));
+                    graph.add_exact_edge(
+                        from,
+                        ExactEdge {
+                            target: to,
+                            cost,
+                            converter,
+                        },
+                    );
+                }
+
+                // linear f32 → sRGB src
+                {
+                    let cost = conversion_cost(f32_fmt, src_fmt).saturating_sub(5);
+                    let from = FormatState::new(f32_fmt, ColorSpace::Linear, alpha);
+                    let to = FormatState::new(src_fmt, ColorSpace::Srgb, alpha);
+                    let converter: SurfaceConverter =
+                        Arc::new(move |surface: &Surface| linear_to_srgb(surface, src_fmt, has_alpha));
+                    graph.add_exact_edge(
+                        from,
+                        ExactEdge {
+                            target: to,
+                            cost,
+                            converter,
+                        },
+                    );
+                }
             }
         }
     }
@@ -1067,6 +1115,53 @@ mod tests {
                 "channel {i}: {} vs {}",
                 back.data[i],
                 surface.data[i],
+            );
+        }
+    }
+
+    #[test]
+    fn srgb_roundtrip_f16_surface() {
+        // 1x1 pixel: sRGB values stored as F16
+        let r = half::f16::from_f64(128.0 / 255.0);
+        let g = half::f16::from_f64(64.0 / 255.0);
+        let b = half::f16::from_f64(32.0 / 255.0);
+        let a = half::f16::from_f64(200.0 / 255.0);
+
+        let mut data = vec![0u8; 8];
+        data[0..2].copy_from_slice(&r.to_le_bytes());
+        data[2..4].copy_from_slice(&g.to_le_bytes());
+        data[4..6].copy_from_slice(&b.to_le_bytes());
+        data[6..8].copy_from_slice(&a.to_le_bytes());
+
+        let surface = Surface {
+            data,
+            width: 1,
+            height: 1,
+            stride: 8,
+            format: ktx2::Format::R16G16B16A16_SFLOAT,
+            color_space: ColorSpace::Srgb,
+            alpha: AlphaMode::Straight,
+        };
+
+        let linear =
+            srgb_to_linear(&surface, ktx2::Format::R32G32B32A32_SFLOAT, true).unwrap();
+        assert_eq!(linear.color_space, ColorSpace::Linear);
+        assert_eq!(linear.format, ktx2::Format::R32G32B32A32_SFLOAT);
+
+        let back =
+            linear_to_srgb(&linear, ktx2::Format::R16G16B16A16_SFLOAT, true).unwrap();
+        assert_eq!(back.color_space, ColorSpace::Srgb);
+        assert_eq!(back.format, ktx2::Format::R16G16B16A16_SFLOAT);
+
+        // Should round-trip within F16 precision.
+        for i in 0..4 {
+            let orig = half::f16::from_le_bytes([surface.data[i * 2], surface.data[i * 2 + 1]]);
+            let result = half::f16::from_le_bytes([back.data[i * 2], back.data[i * 2 + 1]]);
+            assert!(
+                (orig.to_f64() - result.to_f64()).abs() < 1e-3,
+                "channel {i}: {} vs {}",
+                orig,
+                result,
             );
         }
     }

--- a/crates/ctt/src/conversion_graph.rs
+++ b/crates/ctt/src/conversion_graph.rs
@@ -761,15 +761,30 @@ pub fn build_default_graph() -> ConversionGraph {
             F::R32_SFLOAT,
         ),
         (
-            &[F::R8G8_UNORM, F::R16G16_UNORM, F::R16G16_SFLOAT, F::R32G32_SFLOAT],
+            &[
+                F::R8G8_UNORM,
+                F::R16G16_UNORM,
+                F::R16G16_SFLOAT,
+                F::R32G32_SFLOAT,
+            ],
             F::R32G32_SFLOAT,
         ),
         (
-            &[F::R8G8B8_UNORM, F::R16G16B16_UNORM, F::R16G16B16_SFLOAT, F::R32G32B32_SFLOAT],
+            &[
+                F::R8G8B8_UNORM,
+                F::R16G16B16_UNORM,
+                F::R16G16B16_SFLOAT,
+                F::R32G32B32_SFLOAT,
+            ],
             F::R32G32B32_SFLOAT,
         ),
         (
-            &[F::R8G8B8A8_UNORM, F::R16G16B16A16_UNORM, F::R16G16B16A16_SFLOAT, F::R32G32B32A32_SFLOAT],
+            &[
+                F::R8G8B8A8_UNORM,
+                F::R16G16B16A16_UNORM,
+                F::R16G16B16A16_SFLOAT,
+                F::R32G32B32A32_SFLOAT,
+            ],
             F::R32G32B32A32_SFLOAT,
         ),
     ];
@@ -790,8 +805,9 @@ pub fn build_default_graph() -> ConversionGraph {
                 {
                     let from = FormatState::new(src_fmt, ColorSpace::Srgb, alpha);
                     let to = FormatState::new(f32_fmt, ColorSpace::Linear, alpha);
-                    let converter: SurfaceConverter =
-                        Arc::new(move |surface: &Surface| srgb_to_linear(surface, f32_fmt, has_alpha));
+                    let converter: SurfaceConverter = Arc::new(move |surface: &Surface| {
+                        srgb_to_linear(surface, f32_fmt, has_alpha)
+                    });
                     graph.add_exact_edge(
                         from,
                         ExactEdge {
@@ -807,8 +823,9 @@ pub fn build_default_graph() -> ConversionGraph {
                     let cost = conversion_cost(f32_fmt, src_fmt).saturating_sub(5);
                     let from = FormatState::new(f32_fmt, ColorSpace::Linear, alpha);
                     let to = FormatState::new(src_fmt, ColorSpace::Srgb, alpha);
-                    let converter: SurfaceConverter =
-                        Arc::new(move |surface: &Surface| linear_to_srgb(surface, src_fmt, has_alpha));
+                    let converter: SurfaceConverter = Arc::new(move |surface: &Surface| {
+                        linear_to_srgb(surface, src_fmt, has_alpha)
+                    });
                     graph.add_exact_edge(
                         from,
                         ExactEdge {
@@ -1143,13 +1160,11 @@ mod tests {
             alpha: AlphaMode::Straight,
         };
 
-        let linear =
-            srgb_to_linear(&surface, ktx2::Format::R32G32B32A32_SFLOAT, true).unwrap();
+        let linear = srgb_to_linear(&surface, ktx2::Format::R32G32B32A32_SFLOAT, true).unwrap();
         assert_eq!(linear.color_space, ColorSpace::Linear);
         assert_eq!(linear.format, ktx2::Format::R32G32B32A32_SFLOAT);
 
-        let back =
-            linear_to_srgb(&linear, ktx2::Format::R16G16B16A16_SFLOAT, true).unwrap();
+        let back = linear_to_srgb(&linear, ktx2::Format::R16G16B16A16_SFLOAT, true).unwrap();
         assert_eq!(back.color_space, ColorSpace::Srgb);
         assert_eq!(back.format, ktx2::Format::R16G16B16A16_SFLOAT);
 

--- a/crates/ctt/src/conversion_graph.rs
+++ b/crates/ctt/src/conversion_graph.rs
@@ -131,8 +131,8 @@ impl FormatState {
     }
 }
 
-/// A directed edge in the conversion graph.
-pub struct ConversionEdge {
+/// A directed edge in the conversion graph with an explicit target state.
+pub struct ExactEdge {
     /// The target format state after conversion.
     pub target: FormatState,
     /// Cost of this conversion (lower is better).
@@ -141,12 +141,26 @@ pub struct ConversionEdge {
     pub converter: SurfaceConverter,
 }
 
+/// A directed edge keyed by format only — color space and alpha mode pass through from the source.
+pub struct FormatEdge {
+    /// The target format (cs/alpha inherited from source).
+    pub target_format: ktx2::Format,
+    /// Cost of this conversion (lower is better).
+    pub cost: u32,
+    /// The function that performs the conversion on a single surface.
+    pub converter: SurfaceConverter,
+}
+
 /// A graph of format conversions with cost-based shortest-path resolution.
 ///
-/// Nodes are [`FormatState`] values. Edges are available conversions with associated costs.
-/// The resolver uses Dijkstra's algorithm to find the cheapest conversion path.
+/// Nodes are [`FormatState`] values. Edges come in two tiers:
+/// - **Format edges**: keyed by format only, color space and alpha pass through from the source.
+/// - **Exact edges**: keyed by full [`FormatState`], for transitions that change color space or alpha.
 pub struct ConversionGraph {
-    edges: HashMap<FormatState, Vec<ConversionEdge>>,
+    /// Edges keyed by format only — cs/alpha pass through from source.
+    format_edges: HashMap<ktx2::Format, Vec<FormatEdge>>,
+    /// Edges keyed by full FormatState — for cs/alpha transitions.
+    exact_edges: HashMap<FormatState, Vec<ExactEdge>>,
 }
 
 impl Default for ConversionGraph {
@@ -158,13 +172,46 @@ impl Default for ConversionGraph {
 impl ConversionGraph {
     pub fn new() -> Self {
         Self {
-            edges: HashMap::new(),
+            format_edges: HashMap::new(),
+            exact_edges: HashMap::new(),
         }
     }
 
-    /// Add a directed conversion edge from `from` to `edge.target`.
-    pub fn add_edge(&mut self, from: FormatState, edge: ConversionEdge) {
-        self.edges.entry(from).or_default().push(edge);
+    /// Add a format-only edge (cs/alpha pass through from source).
+    pub fn add_format_edge(&mut self, from_format: ktx2::Format, edge: FormatEdge) {
+        self.format_edges.entry(from_format).or_default().push(edge);
+    }
+
+    /// Add an exact edge with a specific source and target state.
+    pub fn add_exact_edge(&mut self, from: FormatState, edge: ExactEdge) {
+        self.exact_edges.entry(from).or_default().push(edge);
+    }
+
+    /// Iterate all outgoing edges from `state`, yielding `(target, cost, converter)`.
+    ///
+    /// Format edges have their target resolved using the source state's cs/alpha.
+    fn edges_from(
+        &self,
+        state: FormatState,
+    ) -> impl Iterator<Item = (FormatState, u32, &SurfaceConverter)> {
+        let format_iter = self
+            .format_edges
+            .get(&state.format)
+            .into_iter()
+            .flat_map(move |edges| {
+                edges.iter().map(move |e| {
+                    let target = FormatState::new(e.target_format, state.color_space, state.alpha);
+                    (target, e.cost, &e.converter)
+                })
+            });
+
+        let exact_iter = self
+            .exact_edges
+            .get(&state)
+            .into_iter()
+            .flat_map(|edges| edges.iter().map(|e| (e.target, e.cost, &e.converter)));
+
+        format_iter.chain(exact_iter)
     }
 
     /// Find the shortest path from `from` to `to` using Dijkstra's algorithm.
@@ -192,14 +239,12 @@ impl ConversionGraph {
                 continue;
             }
 
-            if let Some(edges) = self.edges.get(&state) {
-                for edge in edges {
-                    let new_cost = cost + edge.cost;
-                    if new_cost < *dist.get(&edge.target).unwrap_or(&u32::MAX) {
-                        dist.insert(edge.target, new_cost);
-                        prev.insert(edge.target, state);
-                        heap.push(Reverse((new_cost, edge.target)));
-                    }
+            for (target, edge_cost, _) in self.edges_from(state) {
+                let new_cost = cost + edge_cost;
+                if new_cost < *dist.get(&target).unwrap_or(&u32::MAX) {
+                    dist.insert(target, new_cost);
+                    prev.insert(target, state);
+                    heap.push(Reverse((new_cost, target)));
                 }
             }
         }
@@ -233,14 +278,12 @@ impl ConversionGraph {
                 continue;
             }
 
-            if let Some(edges) = self.edges.get(&state) {
-                for edge in edges {
-                    let new_cost = cost + edge.cost;
-                    if new_cost < *dist.get(&edge.target).unwrap_or(&u32::MAX) {
-                        dist.insert(edge.target, new_cost);
-                        prev.insert(edge.target, state);
-                        heap.push(Reverse((new_cost, edge.target)));
-                    }
+            for (target, edge_cost, _) in self.edges_from(state) {
+                let new_cost = cost + edge_cost;
+                if new_cost < *dist.get(&target).unwrap_or(&u32::MAX) {
+                    dist.insert(target, new_cost);
+                    prev.insert(target, state);
+                    heap.push(Reverse((new_cost, target)));
                 }
             }
         }
@@ -250,7 +293,20 @@ impl ConversionGraph {
 
     /// Look up the converter function for a direct single-hop conversion.
     pub fn get_converter(&self, from: FormatState, to: FormatState) -> Option<&SurfaceConverter> {
-        self.edges.get(&from)?.iter().find_map(|edge| {
+        // Check format edges first (cs/alpha pass through).
+        if from.color_space == to.color_space && from.alpha == to.alpha {
+            if let Some(converter) = self.format_edges.get(&from.format).and_then(|edges| {
+                edges
+                    .iter()
+                    .find(|e| e.target_format == to.format)
+                    .map(|e| &e.converter)
+            }) {
+                return Some(converter);
+            }
+        }
+
+        // Check exact edges.
+        self.exact_edges.get(&from)?.iter().find_map(|edge| {
             if edge.target == to {
                 Some(&edge.converter)
             } else {
@@ -399,8 +455,229 @@ fn write_channel(data: &mut [u8], offset: usize, ck: ChannelKind, val: f64) {
     }
 }
 
-/// Build the default conversion graph with edges between the 16 basic uncompressed formats:
-/// `{R, RG, RGB, RGBA} x {U8, U16, F16, F32}`, all at `Linear` color space and `Straight` alpha.
+/// Apply the sRGB EOTF (electro-optical transfer function) to convert a single channel from
+/// sRGB-encoded to linear.
+fn srgb_eotf(c: f64) -> f64 {
+    if c <= 0.04045 {
+        c / 12.92
+    } else {
+        ((c + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// Apply the inverse sRGB EOTF (OETF) to convert a single channel from linear to sRGB-encoded.
+fn srgb_oetf(c: f64) -> f64 {
+    if c <= 0.0031308 {
+        c * 12.92
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+/// Convert a surface from sRGB u8 unorm to linear f32.
+///
+/// RGB channels get the sRGB EOTF applied; alpha (if present) is treated as already linear
+/// and is just rescaled.
+fn srgb_to_linear(surface: &Surface, target: ktx2::Format, has_alpha: bool) -> Result<Surface> {
+    let src_cc = surface
+        .format
+        .channel_count()
+        .expect("unknown src channel count");
+    let dst_cc = target.channel_count().expect("unknown dst channel count");
+
+    let width = surface.width as usize;
+    let height = surface.height as usize;
+    let src_stride = surface.stride as usize;
+    let dst_stride = width * dst_cc * 4; // f32 = 4 bytes
+
+    let mut out = vec![0u8; dst_stride * height];
+
+    for y in 0..height {
+        for x in 0..width {
+            let src_off = y * src_stride + x * src_cc;
+            let dst_off = y * dst_stride + x * dst_cc * 4;
+
+            for ch in 0..dst_cc {
+                let val = if ch < src_cc {
+                    let raw = surface.data[src_off + ch] as f64 / 255.0;
+                    if has_alpha && ch == 3 {
+                        raw // alpha is linear
+                    } else {
+                        srgb_eotf(raw)
+                    }
+                } else if ch == 3 {
+                    1.0 // alpha default
+                } else {
+                    0.0
+                };
+
+                let v = val as f32;
+                let off = dst_off + ch * 4;
+                out[off..off + 4].copy_from_slice(&v.to_le_bytes());
+            }
+        }
+    }
+
+    Ok(Surface {
+        data: out,
+        width: surface.width,
+        height: surface.height,
+        stride: dst_stride as u32,
+        format: target,
+        color_space: ColorSpace::Linear,
+        alpha: surface.alpha,
+    })
+}
+
+/// Convert a surface from linear f32 to sRGB u8 unorm.
+///
+/// RGB channels get the inverse sRGB EOTF applied; alpha (if present) is treated as linear
+/// and is just rescaled.
+fn linear_to_srgb(surface: &Surface, target: ktx2::Format, has_alpha: bool) -> Result<Surface> {
+    let src_cc = surface
+        .format
+        .channel_count()
+        .expect("unknown src channel count");
+    let dst_cc = target.channel_count().expect("unknown dst channel count");
+
+    let width = surface.width as usize;
+    let height = surface.height as usize;
+    let src_stride = surface.stride as usize;
+    let dst_stride = width * dst_cc; // u8 = 1 byte
+
+    let mut out = vec![0u8; dst_stride * height];
+
+    for y in 0..height {
+        for x in 0..width {
+            let src_off = y * src_stride + x * src_cc * 4;
+            let dst_off = y * dst_stride + x * dst_cc;
+
+            for ch in 0..dst_cc {
+                let linear = if ch < src_cc {
+                    let off = src_off + ch * 4;
+                    let bytes = [
+                        surface.data[off],
+                        surface.data[off + 1],
+                        surface.data[off + 2],
+                        surface.data[off + 3],
+                    ];
+                    f32::from_le_bytes(bytes) as f64
+                } else if ch == 3 {
+                    1.0
+                } else {
+                    0.0
+                };
+
+                let encoded = if has_alpha && ch == 3 {
+                    linear // alpha stays linear
+                } else {
+                    srgb_oetf(linear)
+                };
+
+                out[dst_off + ch] = (encoded.clamp(0.0, 1.0) * 255.0).round() as u8;
+            }
+        }
+    }
+
+    Ok(Surface {
+        data: out,
+        width: surface.width,
+        height: surface.height,
+        stride: dst_stride as u32,
+        format: target,
+        color_space: ColorSpace::Srgb,
+        alpha: surface.alpha,
+    })
+}
+
+/// Premultiply alpha: RGB *= A. Operates on normalized [0,1] values.
+fn premultiply_alpha(surface: &Surface) -> Result<Surface> {
+    let cc = surface
+        .format
+        .channel_count()
+        .expect("unknown channel count");
+    let ck = surface.format.channel_kind().expect("unknown channel kind");
+    let cs = ck.byte_size();
+    let bpp = cc * cs;
+
+    assert!(cc == 4, "premultiply_alpha requires 4-channel format");
+
+    let width = surface.width as usize;
+    let height = surface.height as usize;
+    let stride = surface.stride as usize;
+
+    let mut out = surface.data.clone();
+
+    for y in 0..height {
+        for x in 0..width {
+            let off = y * stride + x * bpp;
+            let alpha = read_channel(&surface.data, off + 3 * cs, ck);
+
+            for ch in 0..3 {
+                let val = read_channel(&surface.data, off + ch * cs, ck);
+                write_channel(&mut out, off + ch * cs, ck, val * alpha);
+            }
+        }
+    }
+
+    Ok(Surface {
+        data: out,
+        width: surface.width,
+        height: surface.height,
+        stride: surface.stride,
+        format: surface.format,
+        color_space: surface.color_space,
+        alpha: AlphaMode::Premultiplied,
+    })
+}
+
+/// Unpremultiply alpha: RGB /= A. Operates on normalized [0,1] values.
+fn unpremultiply_alpha(surface: &Surface) -> Result<Surface> {
+    let cc = surface
+        .format
+        .channel_count()
+        .expect("unknown channel count");
+    let ck = surface.format.channel_kind().expect("unknown channel kind");
+    let cs = ck.byte_size();
+    let bpp = cc * cs;
+
+    assert!(cc == 4, "unpremultiply_alpha requires 4-channel format");
+
+    let width = surface.width as usize;
+    let height = surface.height as usize;
+    let stride = surface.stride as usize;
+
+    let mut out = surface.data.clone();
+
+    for y in 0..height {
+        for x in 0..width {
+            let off = y * stride + x * bpp;
+            let alpha = read_channel(&surface.data, off + 3 * cs, ck);
+
+            if alpha > 0.0 {
+                for ch in 0..3 {
+                    let val = read_channel(&surface.data, off + ch * cs, ck);
+                    write_channel(&mut out, off + ch * cs, ck, val / alpha);
+                }
+            }
+        }
+    }
+
+    Ok(Surface {
+        data: out,
+        width: surface.width,
+        height: surface.height,
+        stride: surface.stride,
+        format: surface.format,
+        color_space: surface.color_space,
+        alpha: AlphaMode::Straight,
+    })
+}
+
+/// Build the default conversion graph.
+///
+/// Format edges: `{R, RG, RGB, RGBA} x {U8, U16, F16, F32}` — work at any color space and alpha mode.
+/// Exact edges: sRGB ↔ linear (u8 unorm ↔ f32, alpha stays linear), premultiply/unpremultiply (RGBA, linear only).
 pub fn build_default_graph() -> ConversionGraph {
     use ktx2::Format as F;
 
@@ -425,6 +702,7 @@ pub fn build_default_graph() -> ConversionGraph {
 
     let mut graph = ConversionGraph::new();
 
+    // Format-only edges: format conversion, cs/alpha pass through.
     for &src in &formats {
         for &dst in &formats {
             if src == dst {
@@ -432,18 +710,106 @@ pub fn build_default_graph() -> ConversionGraph {
             }
 
             let cost = conversion_cost(src, dst);
-
             let converter: SurfaceConverter =
                 Arc::new(move |surface: &Surface| convert_surface(surface, dst));
 
-            let from = FormatState::new(src, ColorSpace::Linear, AlphaMode::Straight);
-            let to = FormatState::new(dst, ColorSpace::Linear, AlphaMode::Straight);
-
-            graph.add_edge(
-                from,
-                ConversionEdge {
-                    target: to,
+            graph.add_format_edge(
+                src,
+                FormatEdge {
+                    target_format: dst,
                     cost,
+                    converter,
+                },
+            );
+        }
+    }
+
+    // sRGB ↔ linear exact edges (u8 unorm srgb ↔ f32 linear, alpha stays linear).
+    let srgb_pairs = [
+        (F::R8_UNORM, F::R32_SFLOAT),
+        (F::R8G8_UNORM, F::R32G32_SFLOAT),
+        (F::R8G8B8_UNORM, F::R32G32B32_SFLOAT),
+        (F::R8G8B8A8_UNORM, F::R32G32B32A32_SFLOAT),
+    ];
+
+    for alpha in [
+        AlphaMode::Straight,
+        AlphaMode::Premultiplied,
+        AlphaMode::Opaque,
+    ] {
+        for &(u8_fmt, f32_fmt) in &srgb_pairs {
+            let has_alpha = u8_fmt.channel_count().unwrap_or(0) == 4;
+
+            // sRGB u8 → linear f32
+            {
+                let from = FormatState::new(u8_fmt, ColorSpace::Srgb, alpha);
+                let to = FormatState::new(f32_fmt, ColorSpace::Linear, alpha);
+                let converter: SurfaceConverter =
+                    Arc::new(move |surface: &Surface| srgb_to_linear(surface, f32_fmt, has_alpha));
+                graph.add_exact_edge(
+                    from,
+                    ExactEdge {
+                        target: to,
+                        cost: 10,
+                        converter,
+                    },
+                );
+            }
+
+            // linear f32 → sRGB u8
+            {
+                let from = FormatState::new(f32_fmt, ColorSpace::Linear, alpha);
+                let to = FormatState::new(u8_fmt, ColorSpace::Srgb, alpha);
+                let converter: SurfaceConverter =
+                    Arc::new(move |surface: &Surface| linear_to_srgb(surface, u8_fmt, has_alpha));
+                graph.add_exact_edge(
+                    from,
+                    ExactEdge {
+                        target: to,
+                        cost: 10,
+                        converter,
+                    },
+                );
+            }
+        }
+    }
+
+    // Premultiply/unpremultiply exact edges (RGBA formats, linear only).
+    let rgba_formats = [
+        F::R8G8B8A8_UNORM,
+        F::R16G16B16A16_UNORM,
+        F::R16G16B16A16_SFLOAT,
+        F::R32G32B32A32_SFLOAT,
+    ];
+
+    for &fmt in &rgba_formats {
+        // straight → premultiplied
+        {
+            let from = FormatState::new(fmt, ColorSpace::Linear, AlphaMode::Straight);
+            let to = FormatState::new(fmt, ColorSpace::Linear, AlphaMode::Premultiplied);
+            let converter: SurfaceConverter =
+                Arc::new(move |surface: &Surface| premultiply_alpha(surface));
+            graph.add_exact_edge(
+                from,
+                ExactEdge {
+                    target: to,
+                    cost: 5,
+                    converter,
+                },
+            );
+        }
+
+        // premultiplied → straight
+        {
+            let from = FormatState::new(fmt, ColorSpace::Linear, AlphaMode::Premultiplied);
+            let to = FormatState::new(fmt, ColorSpace::Linear, AlphaMode::Straight);
+            let converter: SurfaceConverter =
+                Arc::new(move |surface: &Surface| unpremultiply_alpha(surface));
+            graph.add_exact_edge(
+                from,
+                ExactEdge {
+                    target: to,
+                    cost: 5,
                     converter,
                 },
             );
@@ -584,13 +950,156 @@ mod tests {
     #[test]
     fn no_path_for_impossible_constraint() {
         let graph = build_default_graph();
+        // Use a constraint that truly can't be satisfied: a format not in the graph.
         let constraint = FormatConstraint {
-            formats: None,
-            color_spaces: Some(vec![ColorSpace::Srgb]),
+            formats: Some(vec![ktx2::Format::R4G4_UNORM_PACK8]),
+            color_spaces: None,
             alpha_modes: None,
         };
         let path = graph.find_path_to_constraint(rgba8_linear(), &constraint);
         assert!(path.is_none());
+    }
+
+    #[test]
+    fn srgb_to_same_format_different_depth() {
+        let graph = build_default_graph();
+        let srgb_u8 = FormatState::new(
+            ktx2::Format::R8G8B8A8_UNORM,
+            ColorSpace::Srgb,
+            AlphaMode::Straight,
+        );
+        let srgb_u16 = FormatState::new(
+            ktx2::Format::R16G16B16A16_UNORM,
+            ColorSpace::Srgb,
+            AlphaMode::Straight,
+        );
+        let path = graph.find_path(srgb_u8, srgb_u16);
+        assert!(path.is_some());
+        let path = path.unwrap();
+        assert_eq!(
+            path.last().unwrap().format,
+            ktx2::Format::R16G16B16A16_UNORM
+        );
+        assert_eq!(path.last().unwrap().color_space, ColorSpace::Srgb);
+    }
+
+    #[test]
+    fn srgb_to_linear_path_exists() {
+        let graph = build_default_graph();
+        let srgb_u8 = FormatState::new(
+            ktx2::Format::R8G8B8A8_UNORM,
+            ColorSpace::Srgb,
+            AlphaMode::Straight,
+        );
+        let linear_f32 = FormatState::new(
+            ktx2::Format::R32G32B32A32_SFLOAT,
+            ColorSpace::Linear,
+            AlphaMode::Straight,
+        );
+        let path = graph.find_path(srgb_u8, linear_f32);
+        assert!(path.is_some());
+        assert_eq!(*path.unwrap().last().unwrap(), linear_f32);
+    }
+
+    #[test]
+    fn linear_to_srgb_path_exists() {
+        let graph = build_default_graph();
+        let linear_f32 = FormatState::new(
+            ktx2::Format::R32G32B32A32_SFLOAT,
+            ColorSpace::Linear,
+            AlphaMode::Straight,
+        );
+        let srgb_u8 = FormatState::new(
+            ktx2::Format::R8G8B8A8_UNORM,
+            ColorSpace::Srgb,
+            AlphaMode::Straight,
+        );
+        let path = graph.find_path(linear_f32, srgb_u8);
+        assert!(path.is_some());
+        assert_eq!(*path.unwrap().last().unwrap(), srgb_u8);
+    }
+
+    #[test]
+    fn premultiply_path_exists() {
+        let graph = build_default_graph();
+        let straight = FormatState::new(
+            ktx2::Format::R8G8B8A8_UNORM,
+            ColorSpace::Linear,
+            AlphaMode::Straight,
+        );
+        let premul = FormatState::new(
+            ktx2::Format::R8G8B8A8_UNORM,
+            ColorSpace::Linear,
+            AlphaMode::Premultiplied,
+        );
+        let path = graph.find_path(straight, premul);
+        assert!(path.is_some());
+    }
+
+    #[test]
+    fn srgb_roundtrip_surface() {
+        // 1x1 pixel: sRGB(128, 64, 32, 200)
+        let surface = Surface {
+            data: vec![128, 64, 32, 200],
+            width: 1,
+            height: 1,
+            stride: 4,
+            format: ktx2::Format::R8G8B8A8_UNORM,
+            color_space: ColorSpace::Srgb,
+            alpha: AlphaMode::Straight,
+        };
+
+        let linear = srgb_to_linear(&surface, ktx2::Format::R32G32B32A32_SFLOAT, true).unwrap();
+        assert_eq!(linear.color_space, ColorSpace::Linear);
+        assert_eq!(linear.format, ktx2::Format::R32G32B32A32_SFLOAT);
+
+        // Alpha should pass through linearly: 200/255
+        let alpha_bytes = &linear.data[12..16];
+        let alpha = f32::from_le_bytes(alpha_bytes.try_into().unwrap());
+        assert!((alpha - 200.0 / 255.0).abs() < 1e-5);
+
+        let back = linear_to_srgb(&linear, ktx2::Format::R8G8B8A8_UNORM, true).unwrap();
+        assert_eq!(back.color_space, ColorSpace::Srgb);
+        // Should round-trip within +-1 due to u8 quantization.
+        for i in 0..4 {
+            assert!(
+                (back.data[i] as i16 - surface.data[i] as i16).unsigned_abs() <= 1,
+                "channel {i}: {} vs {}",
+                back.data[i],
+                surface.data[i],
+            );
+        }
+    }
+
+    #[test]
+    fn premultiply_roundtrip_surface() {
+        // 1x1 pixel with alpha=0.5 (128/255)
+        let surface = Surface {
+            data: vec![200, 100, 50, 128],
+            width: 1,
+            height: 1,
+            stride: 4,
+            format: ktx2::Format::R8G8B8A8_UNORM,
+            color_space: ColorSpace::Linear,
+            alpha: AlphaMode::Straight,
+        };
+
+        let premul = premultiply_alpha(&surface).unwrap();
+        assert_eq!(premul.alpha, AlphaMode::Premultiplied);
+        // Alpha should be unchanged
+        assert_eq!(premul.data[3], 128);
+
+        let back = unpremultiply_alpha(&premul).unwrap();
+        assert_eq!(back.alpha, AlphaMode::Straight);
+        // Should round-trip within +-1
+        for i in 0..4 {
+            assert!(
+                (back.data[i] as i16 - surface.data[i] as i16).unsigned_abs() <= 1,
+                "channel {i}: {} vs {}",
+                back.data[i],
+                surface.data[i],
+            );
+        }
     }
 
     #[test]

--- a/crates/ctt/src/encoders/ispc.rs
+++ b/crates/ctt/src/encoders/ispc.rs
@@ -42,7 +42,7 @@ impl Encoder for IspcEncoder {
         match format {
             F::BC4_UNORM_BLOCK => F::R8_UNORM,
             F::BC5_UNORM_BLOCK => F::R8G8_UNORM,
-            F::BC6H_UFLOAT_BLOCK => F::R16G16B16A16_UNORM,
+            F::BC6H_UFLOAT_BLOCK => F::R16G16B16A16_SFLOAT,
             _ => F::R8G8B8A8_UNORM,
         }
     }
@@ -80,7 +80,7 @@ impl Encoder for IspcEncoder {
                 Ok(itc::bc5::compress_blocks(&surface))
             }
             F::BC6H_UFLOAT_BLOCK => {
-                let surface = itc::Rgba16Surface::new(data, width, height, stride);
+                let surface = itc::RgbaF16Surface::new(data, width, height, stride);
                 let settings = bc6h_settings(quality);
                 Ok(itc::bc6h::compress_blocks(&settings, &surface))
             }

--- a/crates/ctt/src/pipeline.rs
+++ b/crates/ctt/src/pipeline.rs
@@ -253,7 +253,7 @@ fn resolve_transform_chain(
                 Some(path) => {
                     // Insert conversion transforms for each hop.
                     let mut hop_from = current_state;
-                    for hop_to in &path {
+                    for (hop_idx, hop_to) in path.iter().enumerate() {
                         log::debug!(
                             "{label}: auto-convert {hop_from} -> {hop_to} for '{}'",
                             transform.name(),
@@ -261,10 +261,14 @@ fn resolve_transform_chain(
                         let converter = graph.get_converter(hop_from, *hop_to).cloned();
                         match converter {
                             Some(conv) => {
-                                if !allow_lossy {
-                                    if let Err(reason) = check_lossless(hop_from, *hop_to) {
+                                // Check for spurious precision loss in intermediate
+                                // hops. The final hop is the intentional target, so
+                                // it is exempt — the user chose that precision.
+                                let is_last = hop_idx == path.len() - 1;
+                                if !allow_lossy && !is_last {
+                                    if let Err(reason) = check_lossless(initial_state, *hop_to) {
                                         errors.push(Error::LossyConversion {
-                                            from: hop_from.to_string(),
+                                            from: initial_state.to_string(),
                                             to: hop_to.to_string(),
                                             transform: transform.name().to_string(),
                                             reason: reason.to_string(),

--- a/crates/ctt/src/transforms/mod.rs
+++ b/crates/ctt/src/transforms/mod.rs
@@ -1,3 +1,4 @@
 pub mod compress;
 pub mod format_convert;
 pub mod swizzle;
+pub mod target_format;

--- a/crates/ctt/src/transforms/mod.rs
+++ b/crates/ctt/src/transforms/mod.rs
@@ -1,4 +1,5 @@
 pub mod compress;
 pub mod format_convert;
+pub mod output_state;
 pub mod swizzle;
 pub mod target_format;

--- a/crates/ctt/src/transforms/output_state.rs
+++ b/crates/ctt/src/transforms/output_state.rs
@@ -1,0 +1,58 @@
+use crate::alpha::AlphaMode;
+use crate::constraint::FormatConstraint;
+use crate::error::Result;
+use crate::surface::ColorSpace;
+use crate::surface::Image;
+use crate::transform_node::Transform;
+
+/// A no-op transform that constrains the pipeline to a target format state.
+///
+/// Any combination of format, color space, and alpha mode can be constrained independently.
+/// The pipeline resolver will automatically insert conversion steps before this transform
+/// to satisfy its constraints. The transform itself is an identity operation.
+pub struct OutputStateTransform {
+    target_format: Option<ktx2::Format>,
+    target_color_space: Option<ColorSpace>,
+    target_alpha: Option<AlphaMode>,
+}
+
+impl OutputStateTransform {
+    pub fn new(
+        target_format: Option<ktx2::Format>,
+        target_color_space: Option<ColorSpace>,
+        target_alpha: Option<AlphaMode>,
+    ) -> Self {
+        Self {
+            target_format,
+            target_color_space,
+            target_alpha,
+        }
+    }
+}
+
+impl Transform for OutputStateTransform {
+    fn name(&self) -> &str {
+        "output_state"
+    }
+
+    fn constraint(&self) -> FormatConstraint {
+        FormatConstraint {
+            formats: self.target_format.map(|f| vec![f]),
+            color_spaces: self.target_color_space.map(|cs| vec![cs]),
+            alpha_modes: self.target_alpha.map(|a| vec![a]),
+        }
+    }
+
+    fn output_format(
+        &self,
+        input: ktx2::Format,
+        cs: ColorSpace,
+        alpha: AlphaMode,
+    ) -> (ktx2::Format, ColorSpace, AlphaMode) {
+        (input, cs, alpha)
+    }
+
+    fn execute(&self, image: Image) -> Result<Image> {
+        Ok(image)
+    }
+}

--- a/crates/ctt/src/transforms/target_format.rs
+++ b/crates/ctt/src/transforms/target_format.rs
@@ -1,0 +1,47 @@
+use crate::alpha::AlphaMode;
+use crate::constraint::FormatConstraint;
+use crate::error::Result;
+use crate::surface::ColorSpace;
+use crate::surface::Image;
+use crate::transform_node::Transform;
+
+/// A no-op transform that constrains the pipeline to a specific uncompressed format.
+///
+/// The pipeline resolver will automatically insert format conversion steps before this
+/// transform to satisfy its constraint. The transform itself is an identity operation.
+pub struct TargetFormatTransform {
+    target_format: ktx2::Format,
+}
+
+impl TargetFormatTransform {
+    pub fn new(target_format: ktx2::Format) -> Self {
+        Self { target_format }
+    }
+}
+
+impl Transform for TargetFormatTransform {
+    fn name(&self) -> &str {
+        "target_format"
+    }
+
+    fn constraint(&self) -> FormatConstraint {
+        FormatConstraint {
+            formats: Some(vec![self.target_format]),
+            color_spaces: None,
+            alpha_modes: None,
+        }
+    }
+
+    fn output_format(
+        &self,
+        input: ktx2::Format,
+        cs: ColorSpace,
+        alpha: AlphaMode,
+    ) -> (ktx2::Format, ColorSpace, AlphaMode) {
+        (input, cs, alpha)
+    }
+
+    fn execute(&self, image: Image) -> Result<Image> {
+        Ok(image)
+    }
+}


### PR DESCRIPTION
- Split ConversionGraph edges into two tiers: format edges (format-only, color space/alpha pass through) and exact edges (full      FormatState transitions for sRGB/linear and premultiply/unpremultiply conversions)                                                  - Added sRGB EOTF/OETF transfer functions and premultiply/unpremultiply alpha operations, all wired into the graph as exact edges 
  through f32 intermediates                                                                                                      
- New OutputStateTransform — a no-op constraint transform that lets the pipeline auto-insert color space and alpha conversions
before compression or output
- CLI: replaced --color-space with separate --input-color-space/--input-alpha and --output-color-space/--output-alpha flags (with 
short aliases --ic, --ia, --oc, --oa)
- Fixed BC6H encoder to use RgbaF16Surface (half-float) instead of Rgba16Surface (u16). Closes #24
- Fixed lossy conversion check to compare against initial state rather than intermediate hops, and made constraint search preserve
unconstrained properties (cs/alpha) from the source